### PR TITLE
Fix button args type

### DIFF
--- a/new/src/Socket/messages-send.ts
+++ b/new/src/Socket/messages-send.ts
@@ -691,20 +691,20 @@ export const makeMessagesSocket = (config: SocketConfig) => {
                 }
         }
 
-        const getButtonArgs = (message: proto.IMessage) => {
-                if (message.templateMessage) {
-                        // TODO: Add attributes
-                        return {}
-                } else if (message.listMessage) {
-                        const type = message.listMessage.listType
-                        if (!type) {
-                                throw new Boom('Expected list type inside message')
-                        }
-                        return { v: '2', type: ListType[type].toLowerCase() }
-                } else {
-                        return {}
-                }
-        }
+       const getButtonArgs = (message: proto.IMessage): Record<string, string> => {
+               if (message.templateMessage) {
+                       // TODO: Add attributes
+                       return {}
+               } else if (message.listMessage) {
+                       const type = message.listMessage.listType
+                       if (!type) {
+                               throw new Boom('Expected list type inside message')
+                       }
+                       return { v: '2', type: ListType[type].toLowerCase() }
+               } else {
+                       return {}
+               }
+       }
 
 	const getPrivacyTokens = async (jids: string[]) => {
 		const t = unixTimestampSeconds().toString()


### PR DESCRIPTION
## Summary
- fix return type of `getButtonArgs` to satisfy Record<string,string>

## Testing
- `npm --prefix new run build:tsc` *(fails: Cannot find name 'Buffer', missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_b_683ac358b2c48327aa4062f6ca8b2507