### PR TITLE
Add list message support

### DIFF
--- a/active/src/Types/Message.ts
+++ b/active/src/Types/Message.ts
@@ -191,17 +191,28 @@ export type AnyRegularMessageContent = (
 			buttonReply: ButtonReplyInfo
 			type: 'template' | 'plain'
 	  }
-	| {
-			groupInvite: GroupInviteInfo
-	  }
-	| {
-			listReply: Omit<proto.Message.IListResponseMessage, 'contextInfo'>
-	  }
-	| {
-			pin: WAMessageKey
-			type: proto.PinInChat.Type
-			/**
-			 * 24 hours, 7 days, 30 days
+        | {
+                        groupInvite: GroupInviteInfo
+          }
+        | {
+                        listReply: Omit<proto.Message.IListResponseMessage, 'contextInfo'>
+          }
+       | ({
+                       /** interactive list message */
+                       sections: proto.Message.ListMessage.ISection[]
+                       buttonText: string
+                       text?: string
+                       title?: string
+                       footer?: string
+                       listType?: proto.Message.ListMessage.ListType
+         } & Mentionable &
+                       Contextable &
+                       Editable)
+        | {
+                        pin: WAMessageKey
+                        type: proto.PinInChat.Type
+                        /**
+                         * 24 hours, 7 days, 30 days
 			 */
 			time?: 86400 | 604800 | 2592000
 	  }

--- a/active/src/Utils/messages.ts
+++ b/active/src/Utils/messages.ts
@@ -366,6 +366,18 @@ export const generateWAMessageContent = async (
                                }
                        }
                }
+       } else if ('sections' in message) {
+               const listMessage: proto.Message.IListMessage = {
+                       sections: message.sections,
+                       buttonText: message.buttonText,
+                       title: message.title,
+                       footerText: message.footer,
+                       description: message.text,
+                       listType: Object.prototype.hasOwnProperty.call(message, 'listType')
+                               ? message.listType
+                               : proto.Message.ListMessage.ListType.SINGLE_SELECT
+               }
+               m = { listMessage }
        } else if ('text' in message) {
 		const extContent = { text: message.text } as WATextMessage
 


### PR DESCRIPTION
## Summary
- support list messages via `sections` in `generateWAMessageContent`
- expose list message type in message types

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ae53cbc2083278db0fb1b800a6085